### PR TITLE
set the dashboard link if on jupyterhub

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ cluster = dask_hpcconfig.cluster(name)
 where `name` is the name of one of the available clusters.
 
 To override any particular setting:
-For example on 'datarmor-local' to use only 7 workers for increasing memory size of each worker: 
+For example on 'datarmor-local' to use only 7 workers for increasing memory size of each worker:
 ```python
 overrides = {"cluster.n_workers": 7}
 cluster = dask_hpcconfig.cluster("datarmor-local", **overrides)
 ```
 
-For example on 'datarmor' to use only 7 workers for increasing memory size of each worker, and use 49 workers (i.e. 7 mpi_1 nodes) : 
+For example on 'datarmor' to use only 7 workers for increasing memory size of each worker, and use 49 workers (i.e. 7 mpi_1 nodes) :
 ```python
 overrides = {"cluster.cores": 7}
 cluster = dask_hpcconfig.cluster("datarmor", **overrides)

--- a/dask_hpcconfig/clusters.yaml
+++ b/dask_hpcconfig/clusters.yaml
@@ -46,7 +46,7 @@ datarmor:
         terminate: 0.99  # fraction at which we terminate the worker
     comm:
       compression: null
-      
+
 
 datarmor-seq:
   cluster:


### PR DESCRIPTION
This is detected by checking if the `JUPYTERHUB_USER` environment variable is set and not empty.

- [x] closes #7

This does not solve the issue with the worker logs not being accessible, but I suspect that's a bug in `dask-labextension` and that there's not much we can do here to work around this (but I might be wrong).