### PR TITLE
adapt the `flake8` configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,10 +27,11 @@ dask_hpcconfig =
 
 [flake8]
 ignore =
-    E203 # whitespace before ':' - doesn't work well with black
-    E402 # module level import not at top of file
-    E501 # line too long - let black worry about that
-    E731 # do not assign a lambda expression, use a def
-    W503 # line break before binary operator
+    # E203: whitespace before ':' - doesn't work well with black
+    # E402: module level import not at top of file
+    # E501: line too long - let black worry about that
+    # E731: do not assign a lambda expression, use a def
+    # W503: line break before binary operator
+    E203, E402, E501, E731, W503
 exclude =
     .eggs


### PR DESCRIPTION
The newest version of `flake8` errors if there's inline comments (because inline comments are not interpreted as such by their parser). With this PR, we still get a nice overview of the ignores while being syntactically correct.