### PR TITLE
use the new settings names

### DIFF
--- a/dask_hpcconfig/clusters.yaml
+++ b/dask_hpcconfig/clusters.yaml
@@ -31,7 +31,7 @@ datarmor:
     queue: mpi_1
     death-timeout: 250
     resource-spec: select=1:ncpus=28:mem=120GB
-    job-extra: [-m n]
+    job-extra-directives: [-m n]
     interface: "ib0"
     walltime: "12:00:00"
     local-directory: "$TMPDIR"
@@ -58,7 +58,7 @@ datarmor-seq:
     queue: sequentiel
     death-timeout: 250
     resource-spec: select=1:ncpus=1:mem=4GB
-    job-extra: [-m n]
+    job-extra-directives: [-m n]
     interface: "ib0"
     walltime: "12:00:00"
     local-directory: "$TMPDIR"

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ include_package_data = True
 python_requires = >=3.8
 install_requires =
     pyyaml
-    dask-jobqueue
+    dask-jobqueue >=0.8
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
`dask-jobqueue` recently-ish renamed some settings and deprecated the old values. In order to silence the `DeprecationWarning`s, this uses the new settings.