### PR TITLE
add a way to specify the worker memory directly

### DIFF
--- a/dask_hpcconfig/clusters.py
+++ b/dask_hpcconfig/clusters.py
@@ -47,6 +47,117 @@ def set_dashboard_link_jupyterhub(definition):
     return definition
 
 
+def split_spec(spec, separators=[":", ","], key_value_sep="="):
+    for sep in separators:
+        settings_ = [setting.split("=") for setting in spec.split(sep)]
+        if all(len(setting) == 2 for setting in settings_):
+            return dict(settings_), sep
+
+    raise ValueError(f"could not the detect settings separator in {spec!r}")
+
+
+def join_spec(settings, sep, key_value_sep="="):
+    return sep.join(key_value_sep.join(item) for item in settings.items())
+
+
+def update_resource_spec(spec, new_values):
+    settings, sep = split_spec(spec)
+    updated = settings | {k: v for k, v in new_values.items() if k in settings}
+    return join_spec(updated, sep=sep)
+
+
+def format_resource_size(n):
+    for prefix, k in (
+        ("P", 2**50),
+        ("T", 2**40),
+        ("G", 2**30),
+        ("M", 2**20),
+        ("k", 2**10),
+    ):
+        if n >= k * 0.9:
+            return f"{round(n / k)}{prefix}B"
+
+    return f"{n}B"
+
+
+def expand_custom_cluster_settings(definition):
+    """
+    compute the total resources
+
+    The options to control resource usage are:
+    - job memory (`memory`)
+    - per worker memory (`memory_limit`)
+    - number of workers (`processes`)
+
+    Since `memory` has to always be specified as an upper limit, this leaves us with three
+    combinations:
+    - `memory` and `memory_limit`: compute processes and adjust `memory`
+    - `memory` and `processes`: standard mode: just pass everything as is
+    - `processes` and `memory_limit`: compute new memory
+
+    These will fail if
+    - `processes` would be 0
+    - the computed `memory` would exceed the given maximum value
+    """
+
+    cluster_config = definition.get("cluster")
+    if cluster is None:
+        # invalid, but the error is raised later
+        return definition
+
+    memory = cluster_config.get("memory")
+    if memory is None:
+        # the memory has to be set
+        return definition
+
+    # pop because 'memory_limit' is a custom setting
+    memory_limit = cluster_config.pop("memory_limit")
+    processes = cluster_config.get("processes")
+
+    memory_ = dask.utils.parse_bytes(memory)
+    memory_limit_ = dask.utils.parse_bytes(memory_limit)
+
+    if memory_limit is not None and processes is None:
+        # translate "memory_limit" to processes, and possibly adjust "memory"
+        processes_ = memory_ // memory_limit_
+        if processes_ == 0:
+            raise ValueError(
+                "invalid memory_limit:"
+                f" per worker memory ({memory_limit}) must be smaller"
+                f" or equal to the total memory ({memory})"
+            )
+
+        new_memory_ = processes_ * memory_limit_
+    elif memory_limit is not None and processes is not None:
+        processes_ = processes
+        new_memory_ = processes_ * memory_limit_
+    else:
+        # nothing to do
+        return definition
+
+    new_memory = dask.utils.format_bytes(new_memory_)
+    if new_memory_ > memory_:
+        raise ValueError(
+            f"the requested combination of 'memory_limit' ({memory_limit})"
+            f" and 'processes' ({processes}) exceeds the total memory:"
+            f" {new_memory} > {memory}"
+        )
+
+    new_settings = {"memory": new_memory, "processes": processes_}
+    cluster_config.update(new_settings)
+
+    normalized = dask.config.canonical_name("resource_spec", cluster_config)
+    if normalized in cluster_config:
+        cluster_config[normalized] = update_resource_spec(
+            cluster_config[normalized],
+            {"mem": format_resource_size(new_memory_)},
+        )
+
+    definition["cluster"] = cluster_config
+
+    return definition
+
+
 def cluster(name, *, asynchronous=False, loop=None, **overrides):
     definitions = load_cluster_definitions()
 
@@ -66,6 +177,9 @@ def cluster(name, *, asynchronous=False, loop=None, **overrides):
         dask.config.update(definition, inflate_mapping(overrides))
     )
 
+    # convert special configuration settings
+    definition = expand_custom_cluster_settings(definition)
+
     # split cluster from general config
     cluster_config = definition.get("cluster")
     if cluster_config is None:
@@ -73,11 +187,13 @@ def cluster(name, *, asynchronous=False, loop=None, **overrides):
             f"cluster: malformed cluster definition of {name}: needs at least the 'cluster' key"
         )
 
+    return definition
+
     # instantiate cluster class
     cluster = new_cluster(name, cluster_config, asynchronous=asynchronous)
 
     # feed every other setting to `dask.config.merge` before passing it to `dask.config.set` (because
-    # that is replaces any top-level attributes)
+    # that replaces any top-level attributes)
     merged = dask.config.merge(
         dask.config.config, {k: v for k, v in definition.items() if k != "cluster"}
     )

--- a/dask_hpcconfig/clusters.py
+++ b/dask_hpcconfig/clusters.py
@@ -1,8 +1,7 @@
-import os
-
 import dask
 
 from .definitions import load_cluster_definitions
+from .processors import expand_custom_cluster_settings, set_dashboard_link_jupyterhub
 from .types import _cluster_type
 
 
@@ -34,128 +33,6 @@ def inflate_mapping(mapping):
         assign_nested(new, k.split("."), v)
 
     return new
-
-
-def set_dashboard_link_jupyterhub(definition):
-    # hack to work around a bug in dask-labextension
-    jupyterhub_user = os.environ.get("JUPYTERHUB_USER")
-    if jupyterhub_user:
-        dashboard_link = "/user/{JUPYTERHUB_USER}/proxy/{port}/status"
-        extra_configuration = {"distributed": {"dashboard": {"link": dashboard_link}}}
-        definition = dask.config.update(definition, extra_configuration)
-
-    return definition
-
-
-def split_spec(spec, separators=[":", ","], key_value_sep="="):
-    for sep in separators:
-        settings_ = [setting.split("=") for setting in spec.split(sep)]
-        if all(len(setting) == 2 for setting in settings_):
-            return dict(settings_), sep
-
-    raise ValueError(f"could not the detect settings separator in {spec!r}")
-
-
-def join_spec(settings, sep, key_value_sep="="):
-    return sep.join(key_value_sep.join(item) for item in settings.items())
-
-
-def update_resource_spec(spec, new_values):
-    settings, sep = split_spec(spec)
-    updated = settings | {k: v for k, v in new_values.items() if k in settings}
-    return join_spec(updated, sep=sep)
-
-
-def format_resource_size(n):
-    for prefix, k in (
-        ("P", 2**50),
-        ("T", 2**40),
-        ("G", 2**30),
-        ("M", 2**20),
-        ("k", 2**10),
-    ):
-        if n >= k * 0.9:
-            return f"{round(n / k)}{prefix}B"
-
-    return f"{n}B"
-
-
-def expand_custom_cluster_settings(definition):
-    """
-    compute the total resources
-
-    The options to control resource usage are:
-    - job memory (`memory`)
-    - per worker memory (`memory_limit`)
-    - number of workers (`processes`)
-
-    Since `memory` has to always be specified as an upper limit, this leaves us with three
-    combinations:
-    - `memory` and `memory_limit`: compute processes and adjust `memory`
-    - `memory` and `processes`: standard mode: just pass everything as is
-    - `processes` and `memory_limit`: compute new memory
-
-    These will fail if
-    - `processes` would be 0
-    - the computed `memory` would exceed the given maximum value
-    """
-
-    cluster_config = definition.get("cluster")
-    if cluster is None:
-        # invalid, but the error is raised later
-        return definition
-
-    memory = cluster_config.get("memory")
-    if memory is None:
-        # the memory has to be set
-        return definition
-
-    # pop because 'memory_limit' is a custom setting
-    memory_limit = cluster_config.pop("memory_limit")
-    processes = cluster_config.get("processes")
-
-    memory_ = dask.utils.parse_bytes(memory)
-    memory_limit_ = dask.utils.parse_bytes(memory_limit)
-
-    if memory_limit is not None and processes is None:
-        # translate "memory_limit" to processes, and possibly adjust "memory"
-        processes_ = memory_ // memory_limit_
-        if processes_ == 0:
-            raise ValueError(
-                "invalid memory_limit:"
-                f" per worker memory ({memory_limit}) must be smaller"
-                f" or equal to the total memory ({memory})"
-            )
-
-        new_memory_ = processes_ * memory_limit_
-    elif memory_limit is not None and processes is not None:
-        processes_ = processes
-        new_memory_ = processes_ * memory_limit_
-    else:
-        # nothing to do
-        return definition
-
-    new_memory = dask.utils.format_bytes(new_memory_)
-    if new_memory_ > memory_:
-        raise ValueError(
-            f"the requested combination of 'memory_limit' ({memory_limit})"
-            f" and 'processes' ({processes}) exceeds the total memory:"
-            f" {new_memory} > {memory}"
-        )
-
-    new_settings = {"memory": new_memory, "processes": processes_}
-    cluster_config.update(new_settings)
-
-    normalized = dask.config.canonical_name("resource_spec", cluster_config)
-    if normalized in cluster_config:
-        cluster_config[normalized] = update_resource_spec(
-            cluster_config[normalized],
-            {"mem": format_resource_size(new_memory_)},
-        )
-
-    definition["cluster"] = cluster_config
-
-    return definition
 
 
 def cluster(name, *, asynchronous=False, loop=None, **overrides):

--- a/dask_hpcconfig/clusters.py
+++ b/dask_hpcconfig/clusters.py
@@ -187,8 +187,6 @@ def cluster(name, *, asynchronous=False, loop=None, **overrides):
             f"cluster: malformed cluster definition of {name}: needs at least the 'cluster' key"
         )
 
-    return definition
-
     # instantiate cluster class
     cluster = new_cluster(name, cluster_config, asynchronous=asynchronous)
 

--- a/dask_hpcconfig/clusters.yaml
+++ b/dask_hpcconfig/clusters.yaml
@@ -30,7 +30,7 @@ datarmor:
     processes: 14
     queue: mpi_1
     death-timeout: 250
-    resource-spec: select=1:ncpus=28:mem=120GB
+    # resource-spec: select=1:ncpus=28:mem=120GB
     job-extra-directives: [-m n]
     interface: "ib0"
     walltime: "12:00:00"

--- a/dask_hpcconfig/processors.py
+++ b/dask_hpcconfig/processors.py
@@ -1,0 +1,125 @@
+import os
+
+import dask
+
+
+def set_dashboard_link_jupyterhub(definition):
+    # hack to work around a bug in dask-labextension
+    jupyterhub_user = os.environ.get("JUPYTERHUB_USER")
+    if jupyterhub_user:
+        dashboard_link = "/user/{JUPYTERHUB_USER}/proxy/{port}/status"
+        extra_configuration = {"distributed": {"dashboard": {"link": dashboard_link}}}
+        definition = dask.config.update(definition, extra_configuration)
+
+    return definition
+
+
+def split_spec(spec, separators=[":", ","], key_value_sep="="):
+    for sep in separators:
+        settings_ = [setting.split("=") for setting in spec.split(sep)]
+        if all(len(setting) == 2 for setting in settings_):
+            return dict(settings_), sep
+
+    raise ValueError(f"could not the detect settings separator in {spec!r}")
+
+
+def join_spec(settings, sep, key_value_sep="="):
+    return sep.join(key_value_sep.join(item) for item in settings.items())
+
+
+def update_resource_spec(spec, new_values):
+    settings, sep = split_spec(spec)
+    updated = settings | {k: v for k, v in new_values.items() if k in settings}
+    return join_spec(updated, sep=sep)
+
+
+def format_resource_size(n):
+    for prefix, k in (
+        ("P", 2**50),
+        ("T", 2**40),
+        ("G", 2**30),
+        ("M", 2**20),
+        ("k", 2**10),
+    ):
+        if n >= k * 0.9:
+            return f"{round(n / k)}{prefix}B"
+
+    return f"{n}B"
+
+
+def expand_custom_cluster_settings(definition):
+    """
+    compute the total resources
+
+    The options to control resource usage are:
+    - job memory (`memory`)
+    - per worker memory (`memory_limit`)
+    - number of workers (`processes`)
+
+    Since `memory` has to always be specified as an upper limit, this leaves us with three
+    combinations:
+    - `memory` and `memory_limit`: compute processes and adjust `memory`
+    - `memory` and `processes`: standard mode: just pass everything as is
+    - `processes` and `memory_limit`: compute new memory
+
+    These will fail if
+    - `processes` would be 0
+    - the computed `memory` would exceed the given maximum value
+    """
+
+    cluster_config = definition.get("cluster")
+    if cluster_config is None:
+        # invalid, but the error is raised later
+        return definition
+
+    memory = cluster_config.get("memory")
+    if memory is None:
+        # the memory has to be set
+        return definition
+
+    # pop because 'memory_limit' is a custom setting
+    memory_limit = cluster_config.pop("memory_limit")
+    processes = cluster_config.get("processes")
+
+    memory_ = dask.utils.parse_bytes(memory)
+    memory_limit_ = dask.utils.parse_bytes(memory_limit)
+
+    if memory_limit is not None and processes is None:
+        # translate "memory_limit" to processes, and possibly adjust "memory"
+        processes_ = memory_ // memory_limit_
+        if processes_ == 0:
+            raise ValueError(
+                "invalid memory_limit:"
+                f" per worker memory ({memory_limit}) must be smaller"
+                f" or equal to the total memory ({memory})"
+            )
+
+        new_memory_ = processes_ * memory_limit_
+    elif memory_limit is not None and processes is not None:
+        processes_ = processes
+        new_memory_ = processes_ * memory_limit_
+    else:
+        # nothing to do
+        return definition
+
+    new_memory = dask.utils.format_bytes(new_memory_)
+    if new_memory_ > memory_:
+        raise ValueError(
+            f"the requested combination of 'memory_limit' ({memory_limit})"
+            f" and 'processes' ({processes}) exceeds the total memory:"
+            f" {new_memory} > {memory}"
+        )
+
+    new_settings = {"memory": new_memory, "processes": processes_}
+    cluster_config.update(new_settings)
+
+    normalized = dask.config.canonical_name("resource_spec", cluster_config)
+    if normalized in cluster_config:
+        cluster_config[normalized] = update_resource_spec(
+            cluster_config[normalized],
+            {"mem": format_resource_size(new_memory_)},
+        )
+
+    definition["cluster"] = cluster_config
+
+    return definition


### PR DESCRIPTION
The current way to control the worker memory is to define the desired worker memory, determine how many workers would fit into a single job, and specify that as the number of workers.

With this, instead, we specify the number of workers per job and automatically get the number of workers that fit into a single job.

A usage example would be:

```python
cluster = dask_hpcconfig.create_cluster("name", **{"cluster.memory_limit": "4GB"})
```

we can also explicitly set the number of workers:

```python
cluster = dask_hpcconfig.create_cluster(
    "name",
    **{"cluster.memory_limit": "4GB", "cluster.processes": 12},
)
```