### PR TITLE
fix the pypi release workflow

### DIFF
--- a/.github/workflows/public.yml
+++ b/.github/workflows/public.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           twine check dist/*
           pip install dist/*.whl
-          python -m blackdoc --version
+          python -c 'import dask_hpcconfig'
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@37f50c210e3d2f9450da2cd423303d6a14a6e29f
         with:


### PR DESCRIPTION
The checks were still from the old repository.