### PR TITLE
fix the per-worker spec

### DIFF
--- a/dask_hpcconfig/processors.py
+++ b/dask_hpcconfig/processors.py
@@ -78,7 +78,7 @@ def expand_custom_cluster_settings(definition):
         return definition
 
     # pop because 'memory_limit' is a custom setting
-    worker_memory = cluster_config.pop("worker_memory")
+    worker_memory = cluster_config.pop("worker_memory", None)
     processes = cluster_config.get("processes")
 
     memory_ = dask.utils.parse_bytes(memory)

--- a/dask_hpcconfig/processors.py
+++ b/dask_hpcconfig/processors.py
@@ -53,14 +53,14 @@ def expand_custom_cluster_settings(definition):
 
     The options to control resource usage are:
     - job memory (`memory`)
-    - per worker memory (`memory_limit`)
+    - per worker memory (`worker_memory`)
     - number of workers (`processes`)
 
     Since `memory` has to always be specified as an upper limit, this leaves us with three
     combinations:
-    - `memory` and `memory_limit`: compute processes and adjust `memory`
+    - `memory` and `worker_memory`: compute processes and adjust `memory`
     - `memory` and `processes`: standard mode: just pass everything as is
-    - `processes` and `memory_limit`: compute new memory
+    - `processes` and `worker_memory`: compute new memory
 
     These will fail if
     - `processes` would be 0
@@ -89,7 +89,7 @@ def expand_custom_cluster_settings(definition):
     )
 
     if worker_memory is not None and processes is None:
-        # translate "memory_limit" to processes, and possibly adjust "memory"
+        # translate "worker_memory" to processes, and possibly adjust "memory"
         processes_ = memory_ // worker_memory_
         if processes_ == 0:
             raise ValueError(

--- a/dask_hpcconfig/processors.py
+++ b/dask_hpcconfig/processors.py
@@ -79,7 +79,7 @@ def expand_custom_cluster_settings(definition):
 
     definition = definition.copy(deep=True)
 
-    # pop because 'memory_limit' is a custom setting
+    # pop because 'worker_memory' is a custom setting
     worker_memory = cluster_config.pop("worker_memory", None)
     processes = cluster_config.get("processes")
 

--- a/dask_hpcconfig/processors.py
+++ b/dask_hpcconfig/processors.py
@@ -67,7 +67,7 @@ def expand_custom_cluster_settings(definition):
     - the computed `memory` would exceed the given maximum value
     """
 
-    cluster_config = definition.get("cluster")
+    cluster_config = definition.get("cluster").copy()
     if cluster_config is None:
         # invalid, but the error is raised later
         return definition
@@ -76,8 +76,6 @@ def expand_custom_cluster_settings(definition):
     if memory is None:
         # the memory has to be set
         return definition
-
-    definition = definition.copy(deep=True)
 
     # pop because 'worker_memory' is a custom setting
     worker_memory = cluster_config.pop("worker_memory", None)

--- a/dask_hpcconfig/processors.py
+++ b/dask_hpcconfig/processors.py
@@ -77,6 +77,8 @@ def expand_custom_cluster_settings(definition):
         # the memory has to be set
         return definition
 
+    definition = definition.copy(deep=True)
+
     # pop because 'memory_limit' is a custom setting
     worker_memory = cluster_config.pop("worker_memory", None)
     processes = cluster_config.get("processes")
@@ -113,7 +115,7 @@ def expand_custom_cluster_settings(definition):
         )
 
     new_settings = {"memory": new_memory, "processes": processes_}
-    cluster_config.update(new_settings)
+    cluster_config = cluster_config | new_settings
 
     normalized = dask.config.canonical_name("resource_spec", cluster_config)
     if normalized in cluster_config:
@@ -122,6 +124,7 @@ def expand_custom_cluster_settings(definition):
             {"mem": format_resource_size(new_memory_)},
         )
 
+    definition = definition.copy()
     definition["cluster"] = cluster_config
 
     return definition

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,11 +15,14 @@ include_package_data = True
 python_requires = >=3.8
 install_requires =
     pyyaml
-    dask-jobqueue >=0.8
 
 [options.entry_points]
 console_scripts =
     dask-hpcconfig=dask_hpcconfig.cli:app
+
+[options.extras_require]
+jobqueue =
+    dask-jobqueue >=0.8
 
 [options.package_data]
 dask_hpcconfig =

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,8 @@ include_package_data = True
 python_requires = >=3.8
 install_requires =
     pyyaml
+    dask >=2022.11.0
+    distributed >=2022.11.0
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This fixes the currently failing worker specs, and changes `dask-jobqueue` to become a optional dependency, and requires `dask` and `distributed` as mandatory dependencies.